### PR TITLE
fix shader compilation on linux

### DIFF
--- a/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
+++ b/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
@@ -31,6 +31,7 @@ public static class ShaderCompiler
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+        pInfo.Environment["WINEDLLOVERRIDES"] = "d3dcompiler_47=n";
 
         using var process = new Process();
         process.StartInfo = pInfo;

--- a/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
+++ b/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
@@ -31,10 +31,22 @@ public static class ShaderCompiler
             UseShellExecute = false,
             CreateNoWindow = true,
         };
-        
+
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            pInfo.Environment["WINEDLLOVERRIDES"] = "d3dcompiler_47=n";
+            const string overrides_key = "WINEDLLOVERRIDES";
+            const string d3d_override = "d3dcompiler_47=n";
+
+            if (!pInfo.Environment.TryGetValue(overrides_key, out var overrides) || string.IsNullOrEmpty(overrides))
+            {
+                overrides = d3d_override;
+            }
+            else
+            {
+                overrides += ";" + d3d_override;
+            }
+
+            pInfo.Environment[overrides_key] = overrides;
         }
 
         using var process = new Process();

--- a/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
+++ b/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
@@ -31,8 +31,11 @@ public static class ShaderCompiler
             UseShellExecute = false,
             CreateNoWindow = true,
         };
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
             pInfo.Environment["WINEDLLOVERRIDES"] = "d3dcompiler_47=n";
+        }
 
         using var process = new Process();
         process.StartInfo = pInfo;

--- a/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
+++ b/src/Tomat.TML.Build.Common/Assets/Effects/ShaderCompiler.cs
@@ -31,7 +31,8 @@ public static class ShaderCompiler
             UseShellExecute = false,
             CreateNoWindow = true,
         };
-        pInfo.Environment["WINEDLLOVERRIDES"] = "d3dcompiler_47=n";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            pInfo.Environment["WINEDLLOVERRIDES"] = "d3dcompiler_47=n";
 
         using var process = new Process();
         process.StartInfo = pInfo;

--- a/src/Tomat.TML.Build.MSBuild/Tasks/CompileShadersTask.cs
+++ b/src/Tomat.TML.Build.MSBuild/Tasks/CompileShadersTask.cs
@@ -46,7 +46,7 @@ public sealed class CompileShadersTask : BaseTask
         }
 
         var fxcExePath = "";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var processStartInfo = new ProcessStartInfo
             {

--- a/src/Tomat.TML.Build.sln.DotSettings
+++ b/src/Tomat.TML.Build.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=advapi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=alpc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=buildtxt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dcompiler/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=devdiv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dxgk/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enablemod/@EntryIndexedValue">True</s:Boolean>
@@ -30,4 +31,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tmodloader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tomat/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=valvesoftware/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winedlloverrides/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winternl/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Tomat.TML.ClientBootstrap/Features/AssetHotReloading/ShaderCompiler.cs
+++ b/src/Tomat.TML.ClientBootstrap/Features/AssetHotReloading/ShaderCompiler.cs
@@ -50,7 +50,7 @@ internal static class Shaderc
         }
 
         var fxcExePath = "";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var processStartInfo = new ProcessStartInfo
             {


### PR DESCRIPTION
fixes wine using its built-in d3dcompiler instead of the packaged one, causing shader compilation to fail